### PR TITLE
Fix CI: replace dead jekyll/builder image with ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,14 @@ jobs:
     name: Build Jekyll
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build the site in the jekyll/builder container
-        run: |
-          export JEKYLL_VERSION=3.8
-          docker run \
-          -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-          -e PAGES_REPO_NWO=${{ github.repository }} \
-          jekyll/builder:$JEKYLL_VERSION /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - name: Install dependencies
+        run: bundle install
+      - name: Build the site
+        run: bundle exec jekyll build --future
+        env:
+          PAGES_REPO_NWO: ${{ github.repository }}


### PR DESCRIPTION
The "Beautiful Jekyll CI" workflow has been failing on every push (pre-existing, not caused by the new blog post): it builds inside the abandoned `jekyll/builder:3.8` Docker image, which ships Ruby 2.6.3, and the modern `ffi` gem now requires Ruby ≥ 3.0 — so `bundle install` inside the container fails before Jekyll even runs.

## Changes

- Replace the Docker-based build with `ruby/setup-ruby` on Ruby 3.3 + `bundle install` + `bundle exec jekyll build --future`, using the repo's own `Gemfile` (resolves to Jekyll 3.10.0, the same major version GitHub Pages builds with).
- Bump the deprecated `actions/checkout@v2` to `@v4`.
- Keep the `PAGES_REPO_NWO` env var and the `--future` flag from the old setup.

Verified locally on Ruby 3.3.6: `bundle install` resolves cleanly and `jekyll build --future` builds the site (including the new post at `/2026/07/03/website-blank-for-4-seconds/`) with no errors. The push CI run on this branch exercises the new workflow too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjA6ma6koFjEAhZT4pzxLv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjA6ma6koFjEAhZT4pzxLv)_