### PR TITLE
Upgrade to Jekyll 4 and deploy via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,54 @@
-name: Beautiful Jekyll CI
-on: [push, pull_request]
+name: Build and deploy Jekyll site
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+  workflow_dispatch:
+
+# Allow the deploy job to publish to GitHub Pages via OIDC
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, but don't cancel in-progress production runs
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
-    name: Build Jekyll
+    name: Build site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
-      - name: Install dependencies
-        run: bundle install
-      - name: Build the site
-        run: bundle exec jekyll build --future
+          bundler-cache: true
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
-          PAGES_REPO_NWO: ${{ github.repository }}
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Only deploy from the default branch; pull requests are build-only checks
+    if: github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ source "https://rubygems.org"
 gemspec
 
 
-gem "http_parser.rb", "~> 0.8.0"
-gem "webrick", "~> 1.7"
-gem "jemoji", "~> 0.12.0"
+gem "webrick", "~> 1.9"
+gem "jemoji", "~> 0.13.0"

--- a/_config.yml
+++ b/_config.yml
@@ -271,9 +271,9 @@ defaults:
 # Exclude these files from production site
 exclude:
   - CHANGELOG.md
-  - CNAME
   - Gemfile
   - Gemfile.lock
+  - beautiful-jekyll-theme.gemspec
   - LICENSE
   - README.md
   - screenshot.png

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
     "documentation_uri" => "https://github.com/daattali/beautiful-jekyll#readme"
   }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.8"
+  spec.add_runtime_dependency "jekyll", "~> 4.4"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"
-  spec.add_runtime_dependency "kramdown", "~> 2.3.0"
+  spec.add_runtime_dependency "kramdown", "~> 2.5"
 
-  spec.add_development_dependency "bundler", ">= 1.16"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "bundler", ">= 2.3"
+  spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
## What this does

Modernizes the toolchain from the old Jekyll 3.x setup. The site was pinned to **Jekyll 3.8** and built by GitHub Pages' *native* builder, which is permanently locked to Jekyll 3.x and ignores the `Gemfile` version. This upgrades to **Jekyll 4.4.1** and moves deployment to GitHub Actions so the new version actually runs in production.

## Changes

- **`beautiful-jekyll-theme.gemspec`** — `jekyll` `~> 3.8` → `~> 4.4`, `kramdown` `~> 2.3` → `~> 2.5`; dev deps `bundler >= 2.3` and `rake ~> 13.0`.
- **`Gemfile`** — dropped the obsolete `http_parser.rb` pin; bumped `webrick` → `~> 1.9` and `jemoji` → `~> 0.13`.
- **`.github/workflows/ci.yml`** — replaced the build-only check with a **build + deploy** pipeline (`configure-pages` → build with `JEKYLL_ENV=production` → `upload-pages-artifact` → `deploy-pages`). Pull requests build only; `master` deploys.
- **`_config.yml`** — removed `CNAME` from `exclude` so the `martin.ankerl.com` custom domain survives the switch to Actions-based deployment, and excluded the theme gemspec that was previously leaking into the published site.

## Verification

Built with both Jekyll 3.10 and 4.4.1 and diffed the full output — only 14 of 364 files differ, all benign (improved C++ syntax highlighting from the newer bundled Rouge, plus minor whitespace trimming). CNAME is published, and all key pages / feed / sitemap generate correctly.

## Deployment note

The repository's **Pages source has been switched to "GitHub Actions"**, so this workflow takes over publishing once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uHfiX19mfMEGbyK2tXDfP

---
_Generated by [Claude Code](https://claude.ai/code/session_016uHfiX19mfMEGbyK2tXDfP)_