### PR TITLE
Fix absolute URLs and homepage title after Actions migration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -242,6 +242,14 @@ date_format: "%B %-d, %Y"
 # --- You don't need to touch anything below here (but you can if you want) --- #
 #################################################################################
 
+# The base hostname & protocol for the site. Required so that absolute URLs
+# (canonical links, Open Graph/Twitter tags, RSS feed, navbar link) are
+# generated correctly. When the site was built by GitHub Pages' native
+# builder this was injected automatically; building with Jekyll directly
+# (via GitHub Actions) requires setting it explicitly.
+url: "https://martin.ankerl.com"
+baseurl: ""
+
 # Output options (more information on Jekyll's site)
 timezone: "Europe/Vienna"
 markdown: kramdown

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: home
-title: Martin Leitner&#8209;Ankerl
+title: Martin Leitner‑Ankerl
 subtitle: Programming, Nutrition, Health, Bitcoin, ...
 use-site-title: true
 cover-img:


### PR DESCRIPTION
## What this does

Follow-up to the Jekyll 4 / GitHub Actions migration. Building with Jekyll directly no longer auto-injects `site.url` the way GitHub Pages' native builder did, which broke every absolute URL on the site. This also fixes the double-escaped homepage title.

## Changes

- **`_config.yml`** — set `url: "https://martin.ankerl.com"` (and an explicit empty `baseurl`). This repairs:
  - the **navbar / avatar link**, which had collapsed to `href=""` and pointed at whatever page you were currently reading
  - **canonical** tags (were relative `/…`, now absolute)
  - **Open Graph / Twitter** card URLs *and* images
  - the **RSS feed** `<link>`/`<guid>` entries
  - the **sitemap** `<loc>` entries
- **`index.html`** — use a literal non-breaking hyphen (U+2011) instead of the `&#8209;` HTML entity in the homepage title. The entity rendered fine in the `<h1>` but was double-escaped in the `<title>` tag, so the browser tab showed literally `Martin Leitner&#8209;Ankerl`. It now reads **Martin Leitner‑Ankerl** while keeping the non-breaking behaviour in the heading.

## Verification

Built locally with `JEKYLL_ENV=production` and confirmed on the homepage, a sample post, `feed.xml`, and `sitemap.xml`:

| Item | Before | After |
| --- | --- | --- |
| `<title>` | `Martin Leitner&amp;#8209;Ankerl` | `Martin Leitner‑Ankerl` |
| navbar brand href | `""` | `https://martin.ankerl.com/` |
| canonical / og:url | `/…` | `https://martin.ankerl.com/…` |
| og:image / twitter:image | relative | absolute |
| feed & sitemap links | relative | absolute |

CNAME is still emitted, so the custom domain is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uHfiX19mfMEGbyK2tXDfP

---
_Generated by [Claude Code](https://claude.ai/code/session_016uHfiX19mfMEGbyK2tXDfP)_