### PR TITLE
Enable Google Analytics by setting gtag ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,7 +156,7 @@ footer-hover-col: "#0085A1"
 #################################
 
 # Fill in your Google Analytics gtag.js ID to track your website using gtag
-#gtag: ""
+gtag: "G-6Z0M4S8VPL"
 
 # Fill in your Google Analytics ID to track your website using Google Analytics
 #google_analytics: "UA-1083863-1"


### PR DESCRIPTION
## Problem

No analytics data has been arriving. The site was never sending any.

Every option in the Web Analytics section of `_config.yml` was commented out:

```yaml
#gtag: ""
#google_analytics: "UA-1083863-1"
#cloudflare_analytics: ""
#gtm: ""
```

`_includes/gtag.html` wraps its entire script block in `{% if site.gtag %}`, so with no value set the include rendered to nothing and no script tag ever reached the page.

Confirmed against production — `curl https://martin.ankerl.com/` returns zero matches for `gtag`, `googletagmanager`, or the property ID. The only scripts served are Jekyll search, jQuery, Popper, Bootstrap, and the theme JS.

## Not a recent regression

Two findings from the history suggest this is long-standing rather than something that broke lately:

- The ID `G-6Z0M4S8VPL` has never appeared in any commit in this repo — it existed only in the GA console.
- `google_analytics` was already commented out as of `ccb13ca` (Aug 2022); that commit filled in the UA ID but left the line disabled.

Since Universal Analytics stopped collecting at the July 2023 sunset, data most likely dried up then, and the GA4 property was created but never wired into the site.

## Change

One line. No template edits needed — `_includes/gtag.html` already emits the correct snippet with the ID interpolated.

## Verification

A local build was not possible: `bundle install` fails building native extensions (`bigdecimal`, `json`, `racc`) with `mkmf.rb can't find header files for ruby`, which needs `ruby-devel` installed as root.

Verified structurally instead: every layout (`default`, `home`, `page`, `post`) inherits from `base.html`; both `base.html` and `minimal.html` include `head.html` unconditionally; and `{% include gtag.html %}` sits at top level in `head.html` with no surrounding conditional. So setting `site.gtag` places the tag on every page.

That is a structural argument, not an observation of built output. **Please confirm after merge** by re-running `curl -s https://martin.ankerl.com/ | grep -c gtag` or by watching GA4 Realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)