### PR TITLE
Point calculator links at https and use a descriptive anchor

### DIFF
--- a/_posts/2016/2016-01-04-body-fat-comparison-pictures.md
+++ b/_posts/2016/2016-01-04-body-fat-comparison-pictures.md
@@ -10,7 +10,7 @@ categories:
 - health
 ---
 
-Here is a collection of visual body fat charts. Use these to estimate your personal body fat for the [keto calculator](http://keto-calculator.ankerl.com/). See below for men.
+Here is a collection of visual body fat charts. Use these to estimate your personal body fat for the [keto calculator](https://keto-calculator.ankerl.com/). See below for men.
 
 
 ## Women
@@ -36,7 +36,7 @@ As above with the female pictures, here are also two images with the same body f
 
 ## Back to the Keto Calculator
 
-Now when you have made up your mind where about your body fat percentage might be, head back to the [keto calculator](https://keto-calculator.ankerl.com/) and enter your number.
+Now when you have made up your mind where about your body fat percentage might be, head back to the [keto macro calculator](https://keto-calculator.ankerl.com/) and enter your number.
 
 
 ## Sources

--- a/_posts/2016/2016-06-06-analyzing-keto-calculator-demographics.md
+++ b/_posts/2016/2016-06-06-analyzing-keto-calculator-demographics.md
@@ -11,7 +11,7 @@ categories:
 cover-img: /img/2016/06/age.png
 ---
 
-Recently my [Keto Calculator](http://keto-calculator.ankerl.com) has grown huge. So big, that in January 2016 alone I've had 222,781 page views. That is a record for my site, and I have no reason to believe that it will slow down anytime soon. In my quest to make all the visitors as happy as possible, I've done quite a bit of analysis of my visitors to find out what I need to do with my homepage. Here is some of the data that I have gathered using [Google Analytics](http://www.google.com/analytics/).
+Recently my [Keto Calculator](https://keto-calculator.ankerl.com/) has grown huge. So big, that in January 2016 alone I've had 222,781 page views. That is a record for my site, and I have no reason to believe that it will slow down anytime soon. In my quest to make all the visitors as happy as possible, I've done quite a bit of analysis of my visitors to find out what I need to do with my homepage. Here is some of the data that I have gathered using [Google Analytics](http://www.google.com/analytics/).
 
 Each graph is color coded: _blue_ stands for mobile devices, _orange_ for tablets, and _green_ for desktops.
 


### PR DESCRIPTION
Part of the keto-calculator SEO push (companion to keto-calculator PRs #7): the body-fat and demographics posts linked keto-calculator.ankerl.com over plain `http://` (a redirect hop that dilutes the links), and the high-traffic body-fat post's second link now uses the descriptive anchor "keto macro calculator" — the query the calculator ranks weakest for despite being its exact topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GouHHXYtinKnRvD2nGCwqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GouHHXYtinKnRvD2nGCwqK)_